### PR TITLE
Harden UI session handling and CORS

### DIFF
--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 import aiohttp
 from aiohttp import web
+import logging
 # Import settings before first use
 from .config import settings
 # Config specific to your Discord App (from Developer Portal)
@@ -234,7 +235,8 @@ async def save_schedule(request):
         }
         SCHEDULE_PATH.write_text(json.dumps(payload), encoding="utf-8")
     except Exception as e:
-        return _with_cors(web.Response(status=500, text=f"Failed to save schedule: {e}"), request)
+        logging.exception("Unexpected error when saving schedule")
+        return _with_cors(web.Response(status=500, text="Failed to save schedule."), request)
 
     return _with_cors(web.json_response({"status": "ok"}), request)
 


### PR DESCRIPTION
## Summary
- add HMAC-signed session cookies for UI auth instead of returning Discord access tokens
- gate schedule and substitute endpoints behind session permissions and tighten JSON validation
- restrict CORS to configured origins and bind the web UI server to localhost by default

## Testing
- python -m compileall tomcat


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f4140200832d836cb59b9b21f6d5)