### PR TITLE
Fix Discord OAuth session handling and schedule loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@ let members = [];
 let memberById = {};
 let currentVolunteer = null;
 let zoomLevel = 1.0;
-let currentSearchIndex = -1; 
+let currentSearchIndex = -1;
 let apiBase = '';
 let activeView = 'schedule';
 let subSelectedUser = null;
@@ -496,6 +496,7 @@ let prevRequests = [];
 let prevRequestsByDate = {};
 let requestTab = 'available';
 let appInitialized = false;
+let oauthNonce = null;
 
 function displayName(id, fallback="") {
     const byId = memberById[id];
@@ -536,11 +537,38 @@ function normalizeSchedule(incoming) {
     return base;
 }
 
-async function init() {
-    if (appInitialized) return;
+function resetState() {
+    scheduleData = makeEmptySchedule();
+    members = [];
+    memberById = {};
+    currentVolunteer = null;
+    zoomLevel = 1.0;
+    currentSearchIndex = -1;
+    subSelectedUser = null;
+    allowedDates = [];
+    selectedDate = null;
+    subStationsForDate = [];
+    allowedSubMembers = [];
+    calendarMonth = new Date();
+    claimUser = null;
+    openRequests = [];
+    openRequestsByDate = {};
+    prevRequests = [];
+    prevRequestsByDate = {};
+    requestTab = 'available';
+    selectedCells = new Set();
+    anchor = null;
+}
+
+async function init(force = false) {
+    if (appInitialized && !force) return;
     appInitialized = true;
+    if (force) {
+        resetState();
+    }
+
     const urlParams = new URLSearchParams(window.location.search);
-    apiBase = (urlParams.get('api') || '').replace(/\/$/, '');
+    apiBase = (urlParams.get('api') || apiBase || '').replace(/\/$/, '');
     scheduleData = makeEmptySchedule();
 
     updateStickyHeights();
@@ -602,6 +630,10 @@ async function loadSchedule() {
     try {
         const endpoint = apiBase ? `${apiBase}/api/schedule` : '/api/schedule';
         const res = await fetch(endpoint, { method: 'GET', credentials: "include" });
+        if (res.status === 401) {
+            setSaveStatus("Login required", "warn");
+            throw new Error("Unauthorized");
+        }
         if (!res.ok) throw new Error("Load failed");
         const data = await res.json();
         scheduleData = normalizeSchedule(data.schedule);
@@ -1427,21 +1459,55 @@ window.addEventListener('hashchange', () => {
     }
 });
 
-// Run
-init();
-
 </script>
 
 <!-- Discord Auth Integration -->
 <script>
     // --- CONFIGURATION ---
-    const CLIENT_ID = "1341667150066225192"; 
-    const DEFAULT_API = "https://ui.catsofuta.org"; 
+    const CLIENT_ID = "1341667150066225192";
+    const DEFAULT_API = "https://ui.catsofuta.org";
+    const STATE_STORAGE_KEY = 'tc_ui_oauth_nonce';
 
     // Strip search/hash to ensure this matches Discord Portal exactly
     const REDIRECT_URI = window.location.origin + window.location.pathname;
 
     let authState = { token: null, user: null, permissions: {} };
+
+    function rememberNonce(nonce) {
+        oauthNonce = nonce;
+        try {
+            if (nonce) {
+                sessionStorage.setItem(STATE_STORAGE_KEY, nonce);
+            } else {
+                sessionStorage.removeItem(STATE_STORAGE_KEY);
+            }
+        } catch (e) {
+            console.warn('Unable to persist OAuth nonce', e);
+        }
+    }
+
+    function readStoredNonce() {
+        try {
+            return sessionStorage.getItem(STATE_STORAGE_KEY);
+        } catch (e) {
+            return oauthNonce;
+        }
+    }
+
+    function buildState() {
+        const nonce = crypto.randomUUID();
+        rememberNonce(nonce);
+        return btoa(JSON.stringify({ api: apiBase, nonce }));
+    }
+
+    function parseState(stateStr) {
+        try {
+            return JSON.parse(atob(stateStr));
+        } catch (e) {
+            console.warn('Invalid state payload', e);
+            return null;
+        }
+    }
 
     // --- AUTH FLOW ---
     async function initAuth() {
@@ -1452,15 +1518,25 @@ init();
         // Determine API Base
         let currentApi = urlParams.get('api');
         if (state) {
-            try {
-                const stateObj = JSON.parse(atob(state));
-                if (stateObj.api) currentApi = stateObj.api;
-            } catch(e) { console.warn("Invalid state", e); }
+            const stateObj = parseState(state);
+            const storedNonce = readStoredNonce();
+            if (!stateObj || !stateObj.nonce || !storedNonce || stateObj.nonce !== storedNonce) {
+                console.error('State mismatch; aborting login');
+                alert('Login failed: security check did not pass. Please try again.');
+                showLoginButton();
+                return;
+            }
+            if (stateObj.api) currentApi = stateObj.api;
         }
 
         // Set global apiBase
         apiBase = (currentApi || DEFAULT_API).replace(/\/$/, '');
         console.log("Using Backend:", apiBase);
+
+        if (!code) {
+            const resumed = await resumeSession();
+            if (resumed) return;
+        }
 
         if (code) {
             // Returning from Discord Login
@@ -1475,7 +1551,8 @@ init();
             window.history.replaceState({}, document.title, cleanedUrl.pathname + cleanedUrl.search + cleanedUrl.hash);
             
             await exchangeCode(code, REDIRECT_URI);
-        } 
+            return;
+        }
         else if (document.referrer.includes("discord.com") && window.Discord) {
             // Embedded App
             console.log("Discord Activity environment detected...");
@@ -1494,10 +1571,30 @@ init();
                 console.warn("Embedded Auth failed, showing button", e);
                 showLoginButton();
             }
-        } 
+        }
         else {
             // Direct Web Visit
             showLoginButton();
+        }
+    }
+
+    async function resumeSession() {
+        try {
+            const endpoint = `${apiBase}/api/auth/session`;
+            const res = await fetch(endpoint, {
+                method: "GET",
+                credentials: "include"
+            });
+            if (!res.ok) return false;
+            const data = await res.json();
+            authState.user = data.user;
+            authState.permissions = data.permissions;
+            updateUIForUser();
+            await init(true);
+            return true;
+        } catch (e) {
+            console.warn('Session resume failed', e);
+            return false;
         }
     }
 
@@ -1507,26 +1604,27 @@ init();
             if (redirectUri) body.redirect_uri = redirectUri;
 
             const endpoint = `${apiBase}/api/auth/token`;
-            
-        const res = await fetch(endpoint, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify(body)
-        });
 
-        if (!res.ok) {
-            const errText = await res.text();
-            throw new Error(`Server error (${res.status}): ${errText}`);
-        }
+            const res = await fetch(endpoint, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "include",
+                body: JSON.stringify(body)
+            });
+
+            if (!res.ok) {
+                const errText = await res.text();
+                throw new Error(`Server error (${res.status}): ${errText}`);
+            }
 
             const data = await res.json();
             authState.user = data.user;
             authState.permissions = data.permissions;
+            rememberNonce(null);
 
             updateUIForUser();
-            init(); 
-            
+            await init(true);
+
     } catch (e) {
         console.error("Login Error:", e);
         alert("Login failed: " + (e && e.message ? e.message : e));
@@ -1540,8 +1638,7 @@ init();
         
         if (document.getElementById('web-login-overlay')) return;
 
-        const stateObj = { api: apiBase };
-        const stateStr = btoa(JSON.stringify(stateObj));
+        const stateStr = buildState();
 
         const loginUrl = `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=identify+guilds.members.read&state=${stateStr}`;
 

--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -38,6 +38,9 @@ _ALLOWED_ORIGINS = {
 
 _AUTH_DEBUG = os.getenv("UI_AUTH_DEBUG", "false").lower() == "true"
 
+# Officer role configured for elevated permissions (edit schedule, impersonation)
+OFFICER_ROLE_ID = 845035667661783061
+
 
 def _debug(msg: str) -> None:
     """Print lightweight auth/debug traces when enabled."""
@@ -107,6 +110,73 @@ def _get_session_from_request(request: web.Request) -> Optional[dict]:
             token = auth_header.split(" ", 1)[1]
     _debug(f"session cookie_present={bool(token)}")
     return _verify_session(token) if token else None
+
+
+def _issue_session_response(user_info: dict, permissions: dict, request: web.Request) -> web.Response:
+    """Sign a session payload and return a JSON response with cookie set."""
+    now_ts = int(time.time())
+    session_payload = {
+        "user_id": str(user_info.get("id")),
+        "username": user_info.get("username"),
+        "global_name": user_info.get("global_name"),
+        "permissions": permissions,
+        "iat": now_ts,
+        "exp": now_ts + SESSION_TTL_SECONDS,
+    }
+    session_token = _sign_payload(session_payload)
+
+    resp = web.json_response({
+        "user": {
+            "id": user_info.get("id"),
+            "username": user_info.get("username"),
+            "global_name": user_info.get("global_name"),
+        },
+        "permissions": permissions
+    })
+    resp.set_cookie(
+        "tc_session",
+        session_token,
+        max_age=SESSION_TTL_SECONDS,
+        httponly=True,
+        secure=_COOKIE_SECURE,
+        samesite=_COOKIE_SAMESITE,
+    )
+    _debug(f"set-cookie secure={_COOKIE_SECURE} samesite={_COOKIE_SAMESITE}")
+    return _with_cors(resp, request)
+
+
+async def _resolve_member(user_id: int) -> tuple[Optional[discord.Guild], Optional[discord.Member]]:
+    """Find a member in the configured guild or any guild the bot is in."""
+    guild = bot.get_guild(YOUR_GUILD_ID) if "bot" in globals() else None
+    member = guild.get_member(user_id) if guild else None
+    if not member and guild:
+        try:
+            member = await guild.fetch_member(user_id)
+        except Exception:
+            member = None
+
+    if not member and "bot" in globals():
+        for g in bot.guilds:
+            try:
+                candidate = g.get_member(user_id)
+                if not candidate:
+                    candidate = await g.fetch_member(user_id)
+                if candidate:
+                    return g, candidate
+            except Exception:
+                continue
+    return guild, member
+
+
+def _build_permissions(user_roles: list[int]) -> dict:
+    """Calculate permissions based on Discord roles."""
+    is_officer = OFFICER_ROLE_ID in user_roles
+    return {
+        "can_edit_schedule": is_officer,
+        "can_label_photos": ROLES.get("PHOTO_LABELER") in user_roles,
+        "can_view": True,
+        "is_officer": is_officer,
+    }
 
 
 def _require_permissions(
@@ -196,76 +266,42 @@ async def auth_token_exchange(request):
             return _with_cors(web.Response(status=502, text="Failed to fetch user profile"), request)
 
     # CHECK ROLES
-    guild = bot.get_guild(YOUR_GUILD_ID)
-    member = guild.get_member(user_id) if guild else None
-    if not member and guild:
-        try:
-            member = await guild.fetch_member(user_id)
-        except Exception:
-            member = None
-
-    # Fallback: search all guilds the bot is in for this user to avoid hard-coded ID issues
-    if not member:
-        for g in bot.guilds:
-            try:
-                candidate = g.get_member(user_id)
-                if not candidate:
-                    candidate = await g.fetch_member(user_id)
-                if candidate:
-                    guild = g
-                    member = candidate
-                    _debug(f"fallback guild match guild_id={g.id}")
-                    break
-            except Exception:
-                continue
-
+    guild, member = await _resolve_member(user_id)
     if not guild or not member:
         guild_ids = [getattr(g, "id", None) for g in bot.guilds]
         _debug(f"guild/member missing guild={bool(guild)} member={bool(member)} bot_guilds={guild_ids}")
         return _with_cors(web.Response(status=403, text="Unable to validate guild membership"), request)
 
     user_roles = [r.id for r in member.roles] if member else []
+    permissions = _build_permissions(user_roles)
 
-    # Define Officer Role (Make sure this ID is correct)
-    OFFICER_ROLE_ID = 845035667661783061
-    
-    is_officer = OFFICER_ROLE_ID in user_roles
-    permissions = {
-        "can_edit_schedule": is_officer,
-        "can_label_photos": ROLES.get("PHOTO_LABELER") in user_roles,
-        "can_view": True,
-        "is_officer": is_officer
+    return _issue_session_response(user_info, permissions, request)
+
+
+async def get_session(request: web.Request):
+    """Validate an existing session cookie and refresh it."""
+    session = _get_session_from_request(request)
+    if not session:
+        return _with_cors(web.Response(status=401, text="Missing or invalid session"), request)
+
+    try:
+        user_id = int(session.get("user_id"))
+    except Exception:
+        return _with_cors(web.Response(status=400, text="Invalid session payload"), request)
+
+    guild, member = await _resolve_member(user_id)
+    if not guild or not member:
+        return _with_cors(web.Response(status=403, text="Guild membership required"), request)
+
+    user_roles = [r.id for r in member.roles]
+    permissions = _build_permissions(user_roles)
+    user_info = {
+        "id": user_id,
+        "username": session.get("username") or getattr(member, "name", ""),
+        "global_name": session.get("global_name") or getattr(member, "global_name", None),
     }
 
-    now_ts = int(time.time())
-    session_payload = {
-        "user_id": str(user_id),
-        "username": user_info.get("username"),
-        "permissions": permissions,
-        "iat": now_ts,
-        "exp": now_ts + SESSION_TTL_SECONDS,
-    }
-    session_token = _sign_payload(session_payload)
-
-    safe_user = {
-        "id": user_info.get("id"),
-        "username": user_info.get("username"),
-        "global_name": user_info.get("global_name"),
-    }
-    resp = web.json_response({
-        "user": safe_user,
-        "permissions": permissions
-    })
-    resp.set_cookie(
-        "tc_session",
-        session_token,
-        max_age=SESSION_TTL_SECONDS,
-        httponly=True,
-        secure=_COOKIE_SECURE,
-        samesite=_COOKIE_SAMESITE,
-    )
-    _debug(f"set-cookie secure={_COOKIE_SECURE} samesite={_COOKIE_SAMESITE}")
-    return _with_cors(resp, request)
+    return _issue_session_response(user_info, permissions, request)
 
 # --- The Secure Save Endpoint ---
 async def save_schedule(request):
@@ -562,6 +598,9 @@ async def start_web_server(bot):
         return _with_cors(web.Response(status=204), request)
 
     async def options_auth_token(request):
+        return _with_cors(web.Response(status=204), request)
+
+    async def options_auth_session(request):
         return _with_cors(web.Response(status=204), request)
 
     async def options_subrequest(request):
@@ -1003,7 +1042,9 @@ async def start_web_server(bot):
         web.get('/api/members', get_members),
         web.options('/api/members', options_members),
         web.post('/api/auth/token', auth_token_exchange),
+        web.get('/api/auth/session', get_session),
         web.options('/api/auth/token', options_auth_token),
+        web.options('/api/auth/session', options_auth_session),
         web.post('/api/schedule/save', save_schedule),
         web.get('/api/schedule', get_schedule),
         web.options('/api/schedule', options_schedule),


### PR DESCRIPTION
## Summary
- add OAuth nonce validation and session resume flow to the web UI to reliably load the schedule after login
- refresh schedule initialization and error handling to avoid offline mode when authorized
- centralize Discord session validation on the backend with a reusable session endpoint and stricter permission checks

## Testing
- python -m compileall tomcat UserInterface

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242da4db5c832da7380e29d73be10a)