### PR TITLE
Fix sub request ownership checks and default selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,6 +598,7 @@ async function init(force = false) {
     renderGrid();
     renderCalendar();
     updateSubUserOptions();
+    ensureOwnSubUserSelected();
     await loadOpenSubs();
     setRequestTab('available');
     document.getElementById('loading').style.display = 'none';
@@ -1123,6 +1124,23 @@ function updateSubUserOptions() {
         (scheduleData[st] || []).forEach(uid => { if (uid) scheduledIds.add(uid); });
     });
     allowedSubMembers = members.filter(m => m.id && scheduledIds.has(m.id));
+}
+
+function ensureOwnSubUserSelected() {
+    if (!authState.user || authState.permissions.is_officer) return;
+
+    const alreadySelected = subSelectedUser && String(subSelectedUser.id) === String(authState.user.id);
+    if (alreadySelected) {
+        computeAllowedDates();
+        renderCalendar();
+        renderStationsForSelected();
+        return;
+    }
+
+    const match = (members || []).find(m => String(m.id) === String(authState.user.id));
+    const fallbackName = authState.user.global_name || authState.user.username || "Me";
+    const fallbackUser = authState.user.username || authState.user.global_name || "";
+    setSubUser(match || { id: String(authState.user.id), name: fallbackName, user: fallbackUser });
 }
 
 const subUserInput = document.getElementById('sub-user');

--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -718,8 +718,10 @@ async def start_web_server(bot):
                         rec = json.loads(line)
                         if rec.get("id") == target_id:
                             # Permission Check
-                            owner_id = str(rec.get("requester") or rec.get("assignee") or "")
-                            if not is_officer and user_id_str != owner_id:
+                            requester_id = str(rec.get("requester") or "")
+                            assignee_id = str(rec.get("assignee") or "")
+                            is_owner = user_id_str in (requester_id, assignee_id)
+                            if not is_officer and not is_owner:
                                 return _with_cors(web.Response(status=403, text="You can only delete your own items."), request)
                             deleted_item = rec
                             continue # Skip this line (Delete)


### PR DESCRIPTION
## Summary
- auto-select the logged-in volunteer for the sub request form when impersonation is hidden and refresh the allowed dates
- allow either the requester or the assignee to delete their own sub/claim entries when they are not officers

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692543ff42f4832db59660bbbb32d4b2)