### PR TITLE
Potential fix for code scanning alert no. 26: Information exposure through an exception

### DIFF
--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -682,7 +682,10 @@ async def start_web_server(bot):
         try:
             save_stations(stations_payload, update_meta=True)
         except Exception as e:
-            return _with_cors(web.Response(status=500, text=f"Failed to save stations: {e}"), request)
+            logging.exception("Failed to save stations")  # Logs the full stack trace
+            return _with_cors(
+                web.Response(status=500, text="Failed to save stations due to an internal error."), request
+            )
         # Reload and return updated list
         return _with_cors(web.json_response({"stations": station_definitions()}), request)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Austin-J-B/PyTomCat/security/code-scanning/26](https://github.com/Austin-J-B/PyTomCat/security/code-scanning/26)

To fix the information exposure issue, we should not include the raw exception message (`e`) in the HTTP response sent to the client. Instead, we should:

- Return a generic error message to the user, such as "Failed to save stations due to an internal error."
- Log the full exception details (including the stack trace) on the server for debugging purposes.
- Only expose necessary information to the client (e.g., an error code or a generic message).

The minimal fix involves:
- Updating line 685 in `tomcat/main.py` to replace the detailed error message with a generic one.
- Adding a logger call at that point to log the actual exception and stack trace.

No changes to application flow, API, or status codes are needed, just changes in the reported message content and server-side logging. We can use the existing `logging` module to log exceptions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
