### PR TITLE
Potential fix for code scanning alert no. 27: Information exposure through an exception

### DIFF
--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -734,7 +734,8 @@ async def start_web_server(bot):
         except ValueError:
             return _with_cors(web.Response(status=400, text="Invalid date format"), request)
         except Exception as e:
-            return _with_cors(web.Response(status=500, text=f"Save failed: {e}"), request)
+            logging.exception("Error saving feeding checklist")
+            return _with_cors(web.Response(status=500, text="Save failed due to an internal error"), request)
 
     async def submit_subrequest(request):
         """Record a manual sub request."""


### PR DESCRIPTION
Potential fix for [https://github.com/Austin-J-B/PyTomCat/security/code-scanning/27](https://github.com/Austin-J-B/PyTomCat/security/code-scanning/27)

To fix this issue, the exception's details should not be exposed to the end user. Instead, on catching an exception, log the stack trace and error details on the server, and return a generic error message (e.g., "Save failed due to an internal error") in the HTTP response. Implement this change in the `except Exception as e:` block at lines 736–737. You'll need to import (or use the existing) `logging` to log the error and stack trace.

Specifically:
- Add a call to `logging.exception` or `logging.error` in the exception handler to record the detailed error, including the stack trace.
- Replace the user-facing message with a fixed, generic error message, e.g., `"Save failed due to an internal error"`.
- Ensure the fix is only within the shown code in `tomcat/main.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
