### PR TITLE
Potential fix for code scanning alert no. 28: Information exposure through an exception

### DIFF
--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -834,7 +834,8 @@ async def start_web_server(bot):
                     f.write(json.dumps(record) + "\n")
                 records_written.append(record)
         except Exception as e:
-            return _with_cors(web.Response(status=500, text=f"Log error: {e}"), request)
+            logging.exception("Exception occurred while writing sub request log")
+            return _with_cors(web.Response(status=500, text="An internal error occurred"), request)
 
         #Notify Discord once for the batch
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/Austin-J-B/PyTomCat/security/code-scanning/28](https://github.com/Austin-J-B/PyTomCat/security/code-scanning/28)

The best way to fix this problem is to ensure that detailed exception information is not returned to the user. Instead, we should:
- Return a generic error message (such as `"An internal error occurred"`).
- Optionally, log the exception server-side (using `logging.exception` or similar), so developers can still access the stack trace for debugging purposes.

Changes needed:
- Edit the `except Exception as e:` block on lines 836–837.
- Add a call to properly log the exception server-side using the `logging` module.
- Change the user-visible message to a generic one, e.g., `"An internal error occurred"`.

The `logging` module is already imported (line 18), so no new imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
