### PR TITLE
Potential fix for code scanning alert no. 60: Full server-side request forgery

### DIFF
--- a/tomcat/handlers/labeler.py
+++ b/tomcat/handlers/labeler.py
@@ -1949,7 +1949,22 @@ async def _fetch_image_bytes_for_labeler(
     try:
         timeout = aiohttp.ClientTimeout(total=10)
         async with aiohttp.ClientSession(timeout=timeout) as sess:
-            async with sess.get(u) as resp:
+            # Disable automatic redirects so we can re-validate redirect targets.
+            async with sess.get(u, allow_redirects=False) as resp:
+                # Handle a single level of redirect with safety checks.
+                if resp.status in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("Location")
+                    if not location:
+                        return None
+                    # Build absolute URL from redirect location.
+                    redirect_url = str(resp.url.join(location))
+                    if not _is_safe_url_for_fetch(redirect_url):
+                        return None
+                    async with sess.get(redirect_url, allow_redirects=False) as resp2:
+                        if resp2.status != 200:
+                            return None
+                        data = await resp2.read()
+                        return data or None
                 if resp.status != 200:
                     return None
                 data = await resp.read()
@@ -1960,6 +1975,60 @@ async def _fetch_image_bytes_for_labeler(
 
 
 def _is_safe_url_for_fetch(url: str) -> bool:
+    """
+    Return True if the given URL is safe to fetch from this server.
+
+    Safety constraints:
+      - Scheme must be http or https.
+      - Host must be present and resolve to only public IP addresses.
+      - Reject private, loopback, link-local, multicast, and reserved ranges.
+      - Optionally, restrict to common web ports to avoid talking to arbitrary services.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+        if not parsed.hostname:
+            return False
+
+        # Optional: basic port sanity check. Allow default ports and common HTTPS alternatives.
+        port = parsed.port
+        if port is not None and port not in (80, 443, 8080, 8443):
+            return False
+
+        # Resolve hostname and ensure all addresses are public.
+        try:
+            addrinfo_list = socket.getaddrinfo(parsed.hostname, port or (443 if parsed.scheme == "https" else 80))
+        except socket.gaierror:
+            return False
+
+        for family, _, _, _, sockaddr in addrinfo_list:
+            if family == socket.AF_INET:
+                ip_str = sockaddr[0]
+            elif family == socket.AF_INET6:
+                ip_str = sockaddr[0]
+            else:
+                # Unknown family: be conservative.
+                return False
+
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                return False
+
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+            ):
+                return False
+
+        return True
+    except Exception:
+        # On any parsing/resolution error, treat as unsafe.
+        return False
     """Return True if the URL is acceptable for server-side fetching.
 
     This enforces a safe scheme and rejects URLs that resolve to private or loopback


### PR DESCRIPTION
Potential fix for [https://github.com/Austin-J-B/PyTomCat/security/code-scanning/60](https://github.com/Austin-J-B/PyTomCat/security/code-scanning/60)

In general, to fix a full SSRF issue where a user controls the entire URL, you either (a) remove that control by mapping user input to a server-side allowlist of URLs/domains, or (b) enforce strict validation of any user-provided URL, including its scheme, hostname, resolved IP address (and any redirected-to addresses), and port. For this image-fetching helper, we don’t have context to define a precise domain allowlist, but we *do* already have a function `_is_safe_url_for_fetch`; the best non-breaking fix is to strengthen that function and the HTTP client so that no request can end up going to private/loopback/link-local/multicast addresses, non-HTTP(S) schemes, or unexpected ports, even via redirects.

Concretely, we should:
- Implement `_is_safe_url_for_fetch(url: str) -> bool` (currently elided) so that it:
  - Parses the URL with `urllib.parse.urlparse`.
  - Requires scheme to be `http` or `https`.
  - Rejects URLs without a hostname.
  - Resolves the hostname via `socket.getaddrinfo`.
  - For each resolved IP, constructs an `ipaddress.ip_address` and rejects the URL if any are:
    - Private, loopback, link-local, multicast, or reserved.
  - Optionally restricts to a safe port range (for example, allow default ports or common web ports only).
- Enforce the *same* checks on any redirects by:
  - Using a custom `aiohttp` `TraceConfig` callback that inspects `resp.url` (or redirect target) and cancels if `_is_safe_url_for_fetch` returns `False`; or more simply,
  - Disabling redirects in `sess.get` and performing at most one manual redirect while re-validating the new URL.
- Additionally, harden `_fetch_image_bytes_for_labeler`:
  - Ensure it only allows `http`/`https` by relying on `_is_safe_url_for_fetch`.
  - Disable automatic redirects in `sess.get` and handle a small fixed number of redirects manually, re-running `_is_safe_url_for_fetch` on each new URL.

Since we can only change this file, the minimal-impact approach is:
- Define or update `_is_safe_url_for_fetch` using the existing imports `socket`, `ipaddress`, and `urlparse`.
- Change the direct `sess.get(u)` call to:
  - Disable redirects (`allow_redirects=False`).
  - Check for redirect status codes (301, 302, 303, 307, 308); if present, extract the `Location` header, build an absolute URL, validate it with `_is_safe_url_for_fetch`, and (optionally) follow at most one redirect.
  - Never follow or return data from a URL failing `_is_safe_url_for_fetch`.

This keeps the basic “any external image URL is okay” behavior but closes the SSRF vector to internal networks and redirect-based bypasses.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
