### PR TITLE
Fix overnight bugs: dues heartbeat block, cloudflared noise

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,21 +22,11 @@ Running list of follow-ups deferred from active sessions. Add as we go, check of
 
 ## Deferred fixes from earlier sessions
 
-### Message-edit 429s in `CH_CATS_ON_CAMPUS` (channel `941094752697344031`)
-- Overnight log showed 6× `discord.http: We are being rate limited. PATCH /channels/941094752697344031/messages/<id>` at 02:10 UTC.
-- Likely a progress-bar-style edit loop hammering one channel.
-- **Fix**: find the loop, add throttling (e.g., 1.5s between edits) or batch edits.
-
-### Dues sync heartbeat block
-- Overnight log: `[03:00:27] discord.gateway: Shard ID None heartbeat blocked for more than 10 seconds` from `_sync_dues_roles` calling `_edit_distance` synchronously on the event loop.
-- **Fix**: wrap the CPU-bound section in `tomcat/handlers/dues.py` `_sync_dues_roles` with `await asyncio.to_thread(...)` so heartbeats keep firing.
+### Droplet `.env` profile edit interval
+- Local `.env` was updated to `PROFILE_UPDATE_EDIT_MIN_INTERVAL_SEC=4.5` (was `PROFILE_UPDATE_EDIT_DELAY_SEC=1.0`, which caused the 429s in `CH_CATS_ON_CAMPUS`).
+- **Still to do**: confirm the droplet's `.env` is updated too (it was likely copied from the old laptop value).
 
 ## Droplet polish (post-cutover, low priority)
-
-### cloudflared "package manager" warning at boot
-- `scripts/start.py` calls `cloudflared update` at boot. The dpkg-installed binary at `/usr/bin/cloudflared` refuses to self-update and logs `ERR cloudflared was installed by a package manager. Please update using the same method.`
-- Harmless — tunnel still runs. Just log noise.
-- **Fix**: in `start.py`, check whether the cloudflared binary path is under `/usr/` (or `/snap/`, `/opt/`) before calling `cloudflared update`; skip the update call if so.
 
 ### Dependency drift audit (Windows vs requirements.txt)
 - `modal==1.4.2` was pip-installed manually on Windows and never added to `requirements.txt` — caught on droplet cutover when the bot failed with `ModuleNotFoundError`.

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -248,11 +248,22 @@ def main() -> None:
 
     tunnel_cmd = None
     if cloudflared_path.exists() and tunnel_uuid:
-        # Refresh cloudflared, then start the tunnel.
+        # Refresh cloudflared, then start the tunnel. Skip the self-update when
+        # the binary was installed by a package manager — it refuses to update
+        # itself in that case and just logs noise.
         try:
-            subprocess.run([str(cloudflared_path), "update"], check=False)
-        except Exception as exc:
-            print(f"[Tunnel] Update check failed: {exc}")
+            real_path = str(cloudflared_path.resolve()).replace(os.sep, "/")
+            pkg_managed = any(
+                real_path.startswith(prefix)
+                for prefix in ("/usr/", "/snap/", "/opt/")
+            )
+        except Exception:
+            pkg_managed = False
+        if not pkg_managed:
+            try:
+                subprocess.run([str(cloudflared_path), "update"], check=False)
+            except Exception as exc:
+                print(f"[Tunnel] Update check failed: {exc}")
         tunnel_cmd = [
             str(cloudflared_path), "tunnel", 
             "--config", str(CONFIG_PATH), 

--- a/tomcat/handlers/dues.py
+++ b/tomcat/handlers/dues.py
@@ -3237,41 +3237,46 @@ async def _sync_dues_roles(bot, guild, cur_sem: str, today_date) -> tuple[list, 
                     keys.add(k)
         return keys
 
-    role_holder_count = 0
-    valid_role_holder_count = 0
-
-    #Iterate guild members
-    for member in members_list:
-        has_role = role_obj in member.roles
-        member_keys = _member_keys(member)
-        member_has_valid_dues = bool(member_keys & valid_handle_keys)
-        if not member_has_valid_dues and member_keys and valid_handle_keys:
-            #Allow very small handle drift (1 edit) for reasonably long keys
-            for mk in member_keys:
-                if len(mk) < 6:
-                    continue
-                for vk in valid_handle_keys:
-                    if len(vk) < 6:
+    #=== CLASSIFY (CPU-bound) ===
+    # The nested _edit_distance fallback is O(members * member_keys * valid_keys)
+    # and was blocking the gateway heartbeat. Run the whole pass in a worker
+    # thread so the event loop keeps servicing heartbeats.
+    def _classify_all() -> tuple[list[tuple[Any, bool, bool]], int, int]:
+        out: list[tuple[Any, bool, bool]] = []
+        long_valid_keys = [vk for vk in valid_handle_keys if len(vk) >= 6]
+        rh = 0
+        vrh = 0
+        for member in members_list:
+            has_role = role_obj in member.roles
+            member_keys = _member_keys(member)
+            member_has_valid_dues = bool(member_keys & valid_handle_keys)
+            if not member_has_valid_dues and member_keys and long_valid_keys:
+                for mk in member_keys:
+                    if len(mk) < 6:
                         continue
-                    if _edit_distance(mk, vk) <= 1:
-                        member_has_valid_dues = True
+                    for vk in long_valid_keys:
+                        if _edit_distance(mk, vk) <= 1:
+                            member_has_valid_dues = True
+                            break
+                    if member_has_valid_dues:
                         break
+            if has_role:
+                rh += 1
                 if member_has_valid_dues:
-                    break
-        if has_role:
-            role_holder_count += 1
-            if member_has_valid_dues:
-                valid_role_holder_count += 1
-        
-        #=== ROLE ADDITION ===
+                    vrh += 1
+            out.append((member, has_role, member_has_valid_dues))
+        return out, rh, vrh
+
+    classifications, role_holder_count, valid_role_holder_count = await asyncio.to_thread(_classify_all)
+
+    #=== APPLY (I/O-bound) ===
+    for member, has_role, member_has_valid_dues in classifications:
         if member_has_valid_dues and not has_role:
             try:
                 await member.add_roles(role_obj, reason="TomCat: verified dues for current semester")
                 added.append(member)
             except Exception as e:
                 log_action('dues_role_add_error', f'uid={member.id}', str(e))
-        
-        #=== ROLE REMOVAL ===
         elif has_role and not member_has_valid_dues:
             if not allow_removals:
                 continue


### PR DESCRIPTION
- dues: run _sync_dues_roles classification (nested _edit_distance fallback) through asyncio.to_thread so the gateway heartbeat keeps firing during the daily sync. Role add/remove calls still run inline.
- start.py: skip `cloudflared update` when the binary resolves under /usr/, /snap/, or /opt/ — the dpkg-installed droplet binary refuses to self-update and logs an error otherwise.
- TODO: drop the two finished items; note that the droplet .env still needs PROFILE_UPDATE_EDIT_MIN_INTERVAL_SEC bumped (root cause of the CH_CATS_ON_CAMPUS 429s was the env var defaulting to 1.0s, not the throttle code).