### PR TITLE
Fix yolo notebook hang: route tune/train I/O to local SSD

### DIFF
--- a/notebooks/R6_yolo12l.ipynb
+++ b/notebooks/R6_yolo12l.ipynb
@@ -204,6 +204,11 @@
    "source": [
     "from ultralytics import YOLO\n",
     "\n",
+    "# Keep tune working dir on local SSD — Drive sync chokes on per-iteration writes.\n",
+    "LOCAL_RUNS = \"/content/runs\"\n",
+    "if os.path.exists(LOCAL_RUNS): shutil.rmtree(LOCAL_RUNS)\n",
+    "os.makedirs(LOCAL_RUNS, exist_ok=True)\n",
+    "\n",
     "model = YOLO('yolo12l.pt')\n",
     "model.tune(\n",
     "    data=data_yaml,\n",
@@ -212,12 +217,19 @@
     "    optimizer='AdamW',\n",
     "    imgsz=640,\n",
     "    batch=BATCH,\n",
+    "    cache='ram',    # ~12GB for 10k 640px imgs; A100 host has 83GB\n",
+    "    workers=4,      # Colab CPU is limited; default 8 can stall\n",
     "    plots=False, save=False, val=True,\n",
-    "    project=RUN_DIR, name='tune',\n",
+    "    project=LOCAL_RUNS, name='tune',\n",
     ")\n",
-    "best_hyp = os.path.join(RUN_DIR, \"tune\", \"best_hyperparameters.yaml\")\n",
+    "\n",
+    "# Copy run artifacts (incl. best_hyperparameters.yaml) to Drive.\n",
+    "TUNE_DST = os.path.join(RUN_DIR, \"tune\")\n",
+    "if os.path.exists(TUNE_DST): shutil.rmtree(TUNE_DST)\n",
+    "shutil.copytree(os.path.join(LOCAL_RUNS, \"tune\"), TUNE_DST)\n",
+    "best_hyp = os.path.join(TUNE_DST, \"best_hyperparameters.yaml\")\n",
     "print(f\"\\nBest hyperparams: {best_hyp}\")\n",
-    "print(open(best_hyp).read())"
+    "print(open(best_hyp).read())\n"
    ]
   },
   {
@@ -242,13 +254,20 @@
     "    epochs=300,\n",
     "    imgsz=640,\n",
     "    batch=BATCH,\n",
+    "    cache='ram',\n",
+    "    workers=4,\n",
     "    patience=50,\n",
     "    cos_lr=True,\n",
     "    save_period=50,\n",
-    "    project=RUN_DIR, name='final',\n",
+    "    project=LOCAL_RUNS, name='final',\n",
     ")\n",
-    "best_pt = os.path.join(RUN_DIR, \"final\", \"weights\", \"best.pt\")\n",
-    "print(f\"Final best weights: {best_pt}\")"
+    "\n",
+    "# Copy run + best.pt to Drive.\n",
+    "FINAL_DST = os.path.join(RUN_DIR, \"final\")\n",
+    "if os.path.exists(FINAL_DST): shutil.rmtree(FINAL_DST)\n",
+    "shutil.copytree(os.path.join(LOCAL_RUNS, \"final\"), FINAL_DST)\n",
+    "best_pt = os.path.join(FINAL_DST, \"weights\", \"best.pt\")\n",
+    "print(f\"Final best weights: {best_pt}\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

The YOLO tuner hung indefinitely at iteration 1/50 with no further output (~30 min) because `project=RUN_DIR` pointed at a Drive path. Ultralytics' tuner does heavy per-iteration I/O (intermediate checkpoints, logs, plots, dataset cache files) and Drive sync can't keep up — it stalls.

This PR routes the working dir to local SSD (`/content/runs`) and copies the final artifacts (incl. `best_hyperparameters.yaml`, `best.pt`, full run dir) to Drive at the end of each phase. Also adds:
- `cache='ram'` — fits the ~12 GB dataset in A100 host RAM (83 GB), avoids per-epoch disk reads
- `workers=4` — Colab's default of 8 dataloader workers can stall on its limited CPU allocation

## Test plan

- [ ] Re-run `R6_yolo12l.ipynb` from the tune cell; verify iterations actually progress (each iter prints epoch lines + a Tuner fitness update)
- [ ] After tune completes, confirm `R6_yolo12l/tune/best_hyperparameters.yaml` exists in Drive
- [ ] After final train, confirm `R6_yolo12l/final/weights/best.pt` and `R6_cat_yolo12l.pt` land in Drive