### PR TITLE
yolo notebook: add smoke-test cell + cache='ram' → 'disk'

### DIFF
--- a/notebooks/R6_yolo12l.ipynb
+++ b/notebooks/R6_yolo12l.ipynb
@@ -20,15 +20,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# R6 YOLO12l Cat Detector — Tuned + Trained from CSV\n",
+    "# R6 YOLO12l Cat Detector â€” Tuned + Trained from CSV\n",
     "\n",
     "- Model: YOLO12l (26M params; ~50MB on disk)\n",
-    "- Hyperparameter tuning: Ultralytics `model.tune()` — genetic algorithm over 18 params, 50 iterations × 20 epochs\n",
+    "- Hyperparameter tuning: Ultralytics `model.tune()` â€” genetic algorithm over 18 params, 50 iterations Ã— 20 epochs\n",
     "- Final training: 300 epochs with the best mutation, cosine LR, patience=50\n",
     "- Eval: standard mAP + recall sweep across confidence thresholds (the bot's threshold is 0.552)\n",
     "\n",
-    "Deploy target: Modal T4 (~30ms/inference vs YOLO12s's ~10ms — irrelevant next to encoder pass).\n",
-    "Train on A100. T4 can train at batch=4 but takes ~12h+ — not recommended."
+    "Deploy target: Modal T4 (~30ms/inference vs YOLO12s's ~10ms â€” irrelevant next to encoder pass).\n",
+    "Train on A100. T4 can train at batch=4 but takes ~12h+ â€” not recommended."
    ]
   },
   {
@@ -189,7 +189,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Tune — 50 GA iterations × 20 epochs each\n",
+    "## Smoke test â€” one direct training call\n",
+    "\n",
+    "`model.tune()` runs each iteration in a subprocess and only surfaces `returned non-zero exit status 1` on failure â€” the real error is hidden. This cell does a single `model.train()` call so any training-time exception (OOM, corrupt image, bad label, dependency mismatch) prints with a full traceback. **Run this first.** If it completes one epoch successfully, the tune call below will too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from ultralytics import YOLO\n",
+    "import shutil, os\n",
+    "\n",
+    "SMOKE_DIR = '/content/runs/smoke'\n",
+    "if os.path.exists(SMOKE_DIR): shutil.rmtree(SMOKE_DIR)\n",
+    "\n",
+    "smoke_model = YOLO('yolo12l.pt')\n",
+    "smoke_model.train(\n",
+    "    data=data_yaml,\n",
+    "    epochs=1,\n",
+    "    imgsz=640,\n",
+    "    batch=BATCH,\n",
+    "    cache='disk',   # writes preprocessed cache to /content; safer than 'ram'\n",
+    "    workers=2,\n",
+    "    plots=False,\n",
+    "    val=True,\n",
+    "    project='/content/runs', name='smoke', exist_ok=True,\n",
+    ")\n",
+    "print('\\nâœ… smoke test passed â€” safe to run tune below.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tune â€” 50 GA iterations Ã— 20 epochs each\n",
     "\n",
     "Ultralytics' `.tune()` mutates 18 hyperparams (LR, momentum, weight decay, warmup, loss gains, and all augmentation strengths) via a genetic algorithm. Each iteration is a 20-epoch training run; the best mutation seeds the next.\n",
     "\n",
@@ -204,7 +240,7 @@
    "source": [
     "from ultralytics import YOLO\n",
     "\n",
-    "# Keep tune working dir on local SSD — Drive sync chokes on per-iteration writes.\n",
+    "# Keep tune working dir on local SSD â€” Drive sync chokes on per-iteration writes.\n",
     "LOCAL_RUNS = \"/content/runs\"\n",
     "if os.path.exists(LOCAL_RUNS): shutil.rmtree(LOCAL_RUNS)\n",
     "os.makedirs(LOCAL_RUNS, exist_ok=True)\n",
@@ -217,7 +253,7 @@
     "    optimizer='AdamW',\n",
     "    imgsz=640,\n",
     "    batch=BATCH,\n",
-    "    cache='ram',    # ~12GB for 10k 640px imgs; A100 host has 83GB\n",
+    "    cache='disk',    # preprocessed cache on /content SSD; safer than ram across subprocesses\n",
     "    workers=4,      # Colab CPU is limited; default 8 can stall\n",
     "    plots=False, save=False, val=True,\n",
     "    project=LOCAL_RUNS, name='tune',\n",
@@ -236,7 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Final train — 300 epochs with the best mutation\n",
+    "## Final train â€” 300 epochs with the best mutation\n",
     "\n",
     "Cosine LR + early stopping at patience=50. Checkpoint every 50 epochs in case of disconnect."
    ]
@@ -254,7 +290,7 @@
     "    epochs=300,\n",
     "    imgsz=640,\n",
     "    batch=BATCH,\n",
-    "    cache='ram',\n",
+    "    cache='disk',\n",
     "    workers=4,\n",
     "    patience=50,\n",
     "    cos_lr=True,\n",
@@ -274,7 +310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Eval — recall sweep at varied confidence thresholds\n",
+    "## Eval â€” recall sweep at varied confidence thresholds\n",
     "\n",
     "Standard mAP@0.5 + recall at the bot's actual threshold (`cv.detect_conf=0.552`)."
    ]


### PR DESCRIPTION
`model.tune()` runs each iteration in a subprocess and only surfaces 'returned non-zero exit status 1' — the real training error is hidden. Latest run had 53-minute iterations failing silently.

Two changes:
- Insert a smoke-test cell that does a single direct model.train() call before the tune cell. Any real exception (OOM, corrupt image, bad label) prints with a full traceback so we can fix it.
- Switch cache='ram' → 'disk' in smoke/tune/train. RAM cache gets duplicated per subprocess and can OOM if Colab handed out an A100 with low host RAM; 'disk' cache lives on /content SSD (fast, no per-subprocess duplication).