### PR TITLE
vision: bound CV thread fallout + dispatch ? react via raw_reaction_add

### DIFF
--- a/tomcat/config.py
+++ b/tomcat/config.py
@@ -341,9 +341,11 @@ class Settings:
     #Hard budget for auto-crop work in handlers (ms). If exceeded, show original image.
     cv_timeout_ms: int = int(os.getenv("CV_TIMEOUT_MS", "6000"))
     #Timeout floor when CV_BACKEND=modal. Cold paths can include snapshot
-    #restore + GPU move + first inference; 30s leaves headroom without
-    #stranding users. Warm paths still complete in well under 1s.
-    cv_modal_timeout_ms: int = int(os.getenv("CV_MODAL_TIMEOUT_MS", "30000"))
+    #restore + GPU move + first inference plus N rerank round-trips (one per
+    #detected cat). R6 ViT-L cold runs ~15-23s for detect_and_embed alone,
+    #so 60s leaves headroom for a 2-3 cat image on a fully cold container.
+    #Warm paths still complete in well under 1s.
+    cv_modal_timeout_ms: int = int(os.getenv("CV_MODAL_TIMEOUT_MS", "60000"))
     #Interval in seconds for the optional Modal keep-warm pinger. 0 disables
     #(default). Only useful if you want to extend warm time BEYOND the Modal
     #app's scaledown_window (currently 900s = 15 min) — for example, set to

--- a/tomcat/handlers/vision.py
+++ b/tomcat/handlers/vision.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import os
 import io
 import asyncio
+import concurrent.futures
+import time
 import aiohttp
 import discord
 from datetime import timezone
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 
 from ..config import settings
 from ..logger import log_action
@@ -22,12 +24,28 @@ from ..services.vision_feedback import register_identify_feedback
 # concurrent asyncio.to_thread(V.*) calls on the shared module-level models
 # causes deadlocks that permanently freeze the handler coroutine.
 _CV_SEM = asyncio.Semaphore(1)
+
+# Dedicated single-worker executor for V.detect/V.crop/V.identify. Using the
+# default asyncio executor lets an orphaned CV thread (e.g. Modal RPC stuck
+# past wait_for's timeout — the underlying thread has no asyncio-aware cancel)
+# steal a worker from sheet sync, Gmail polling, and the labeler. With
+# max_workers=1, a second CV call queues here instead, and wait_for still
+# times out cleanly — so the fallout from one stuck call is bounded.
+_CV_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="tc-cv"
+)
 _CV_TIMEOUT_SEC = max(6.0, float(getattr(settings, "cv_timeout_ms", 6000)) / 1000.0)
 _CV_MODAL_TIMEOUT_SEC = max(
     _CV_TIMEOUT_SEC,
-    float(getattr(settings, "cv_modal_timeout_ms", 30000)) / 1000.0,
+    float(getattr(settings, "cv_modal_timeout_ms", 60000)) / 1000.0,
 )
 _CV_COLD_TIMEOUT_SEC = 120.0  # generous timeout for first-time model loading
+
+
+async def _run_cv(fn, *args):
+    """Run a blocking CV function on the dedicated single-worker executor."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_CV_EXECUTOR, fn, *args)
 
 
 def _identify_timeout_sec() -> float:
@@ -102,24 +120,42 @@ def _format_confidence_pct(score: Any) -> str:
     value = max(0.0, min(1.0, value))
     return f"{value * 100:.1f}%"
 
-#---------- background reaction listener ----------
-async def _wait_for_top5_reaction(
-    client: Any,
-    reply_msg: discord.Message,
-    embed: discord.Embed,
-    results: list,
-) -> None:
-    """Wait (in the background) for a user to click '?' then expand the embed."""
+#---------- top-5 reaction registry ----------
+# When handle_cv_identify produces results, it registers the embed + results
+# here keyed on the reply message id. on_raw_reaction_add dispatches the \u2753
+# emoji to handle_top5_reaction below, which expands the embed.
+#
+# This replaces the older client.wait_for("reaction_add", ...) approach,
+# which silently no-op'd whenever the reply message had aged out of
+# discord.py's in-memory message cache (default 1000 entries). raw_reaction_add
+# fires for any reaction regardless of cache state.
+_TOP5_TTL_SEC = 1800  # 30 min \u2014 gallery retrain pending TTL is much longer
+_top5_listeners: Dict[int, Tuple[float, discord.Embed, list, discord.Message]] = {}
+
+
+def _gc_top5_listeners(now: float) -> None:
+    expired = [mid for mid, entry in _top5_listeners.items() if now - entry[0] > _TOP5_TTL_SEC]
+    for mid in expired:
+        _top5_listeners.pop(mid, None)
+
+
+def _register_top5_listener(reply_msg: discord.Message, embed: discord.Embed, results: list) -> None:
+    """Remember an identify reply so a later \u2753 react can expand the top-5."""
+    now = time.monotonic()
+    _gc_top5_listeners(now)
+    _top5_listeners[int(reply_msg.id)] = (now, embed, list(results), reply_msg)
+
+
+async def handle_top5_reaction(reply_message_id: int) -> bool:
+    """Expand the embed for a registered identify reply. Returns True if handled.
+
+    Called from main.on_raw_reaction_add when a \u2753 reaction is observed.
+    """
+    entry = _top5_listeners.pop(int(reply_message_id), None)
+    if not entry:
+        return False
+    _, embed, results, reply_msg = entry
     try:
-        def check(reaction, user):
-            return (
-                str(reaction.emoji) == "\u2753"
-                and reaction.message.id == reply_msg.id
-                and not user.bot
-            )
-
-        reaction, user = await client.wait_for("reaction_add", timeout=120.0, check=check)
-
         expanded_lines = []
         for r in results:
             idx = r["index"]
@@ -128,15 +164,12 @@ async def _wait_for_top5_reaction(
             for rank, (c_name, c_conf) in enumerate(top5):
                 expanded_lines.append(f"`{rank+1}.` {c_name} ({_format_confidence_pct(c_conf)})")
             expanded_lines.append("")
-
         embed.description = "\n".join(expanded_lines)
         embed.set_footer(text="Showing Top 5 Candidates")
         await reply_msg.edit(embed=embed)
-
-    except asyncio.TimeoutError:
-        pass
     except Exception as e:
-        log_action("viz_reaction_wait_error", f"err={type(e).__name__}", str(e))
+        log_action("viz_top5_edit_error", f"err={type(e).__name__}", str(e))
+    return True
 
 
 #---------- public handlers ----------
@@ -160,7 +193,7 @@ async def handle_cv_detect(intent: 'Intent', ctx: Dict[str, Any]) -> None:
 
         async with _CV_SEM:
             out = await asyncio.wait_for(
-                asyncio.to_thread(V.detect, data),
+                _run_cv(V.detect, data),
                 timeout=timeout,
             )
         file = discord.File(io.BytesIO(out.boxed_jpeg), filename="detected.jpg")
@@ -200,7 +233,7 @@ async def handle_cv_crop(intent: 'Intent', ctx: Dict[str, Any]) -> None:
 
         async with _CV_SEM:
             out = await asyncio.wait_for(
-                asyncio.to_thread(V.crop, data),
+                _run_cv(V.crop, data),
                 timeout=timeout,
             )
         crop_bytes = list(getattr(out, "crops", []) or [])
@@ -278,7 +311,7 @@ async def handle_cv_identify(intent: 'Intent', ctx: Dict[str, Any]) -> None:
 
         async with _CV_SEM:
             out = await asyncio.wait_for(
-                asyncio.to_thread(V.identify, data),
+                _run_cv(V.identify, data),
                 timeout=timeout,
             )
 
@@ -343,17 +376,10 @@ async def handle_cv_identify(intent: 'Intent', ctx: Dict[str, Any]) -> None:
         if not out.results:
             return
 
-        # ACTIVE LISTENER FOR '?' REACTION
-        # Spawn as a background task so the handler returns immediately and
-        # doesn't hold the dispatch chain alive for up to 2 minutes.
-        client = ctx.get("client")
-        if not client and message.guild:
-            client = message.guild.me._state._get_client()
-
-        if client:
-            asyncio.create_task(
-                _wait_for_top5_reaction(client, reply_msg, embed, out.results)
-            )
+        # Register for '?' reaction dispatch (see _register_top5_listener).
+        # Replaces an earlier client.wait_for() background task that silently
+        # no-op'd whenever reply_msg had aged out of discord.py's message cache.
+        _register_top5_listener(reply_msg, embed, out.results)
 
     except asyncio.TimeoutError:
         log_action("viz_identify_error", "err=TimeoutError", f"cap={timeout:.1f}s")

--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -2081,6 +2081,16 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
             return
     except Exception as e:
         log_action("viz_feedback_reaction_error", f"msg={payload.message_id}", str(e))
+    # ❓ reaction expands the embed to show top-5 candidates per detected cat.
+    # Dispatched via raw_reaction_add (not client.wait_for) so message-cache
+    # eviction doesn't silently drop the response.
+    if str(payload.emoji) == "❓":
+        try:
+            from .handlers.vision import handle_top5_reaction
+            if await handle_top5_reaction(int(payload.message_id)):
+                return
+        except Exception as e:
+            log_action("viz_top5_dispatch_error", f"msg={payload.message_id}", str(e))
     data = SPAM_ALERTS.get(payload.message_id)
     if not data:
         return


### PR DESCRIPTION
After identify times out (wait_for raises TimeoutError), the underlying asyncio.to_thread worker keeps running V.identify against shared module state in tomcat.vision.vision — Modal's blocking .remote() has no asyncio-aware cancel. The semaphore prevents *intentional* concurrent calls but not orphan-vs-fresh races, and the orphan also occupies a worker in the default ThreadPoolExecutor (used by sheet sync, Gmail polling, labeler), starving the rest of the bot.

Three changes:

1. config: cv_modal_timeout_ms default 30000 -> 60000. R6 ViT-L cold detect_and_embed is ~15-23s, plus N rerank round-trips (one per detected cat). 30s was tight enough that a fully cold container with 2-3 cats reliably tripped it.

2. handlers/vision: route V.detect/V.crop/V.identify through a dedicated ThreadPoolExecutor(max_workers=1, "tc-cv") instead of asyncio.to_thread. An orphaned CV thread now blocks only the next CV call (which still times out cleanly via wait_for) rather than bleeding into the shared pool.

3. handlers/vision + main: replace the client.wait_for("reaction_add") background task with a module-level _top5_listeners registry keyed on reply_msg.id, dispatched from on_raw_reaction_add. The old approach silently no-op'd whenever the reply message had aged out of discord.py's in-memory message cache (default 1000 entries), which matches the user-reported "? sometimes does nothing" behavior. raw_reaction_add fires regardless of cache state. Registry has a 30 min TTL with passive GC on insert.

Triggering incident in logs/2026-05-24.ndjson lines 764-790: cold Modal hit the 30s cap on first identify, then again ~12 min later right before a manual restart.