### PR TITLE
deps: bump aiohttp, requests, python-dotenv to clear Dependabot alerts

### DIFF
--- a/requirements-droplet.txt
+++ b/requirements-droplet.txt
@@ -2,8 +2,8 @@
 
 # Core Discord bot stack
 discord.py==2.4.0
-python-dotenv==1.0.1
-aiohttp==3.13.3
+python-dotenv==1.2.2
+aiohttp==3.13.5
 
 # Google Sheets + OAuth
 gspread==6.1.3
@@ -28,7 +28,7 @@ torch==2.8.0
 torchvision==0.23.0
 
 # HTTP utilities
-requests==2.32.4
+requests==2.34.2
 
 # Modal cloud (CV inference offload)
 modal==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 
 #Core Discord bot stack
 discord.py==2.4.0
-python-dotenv==1.0.1
-aiohttp==3.13.3
+python-dotenv==1.2.2
+aiohttp==3.13.5
 
 #Google Sheets + OAuth
 gspread==6.1.3
@@ -28,7 +28,7 @@ torch==2.8.0
 torchvision==0.19.1+cu121
 
 #HTTP utilities
-requests==2.32.4
+requests==2.34.2
 
 #Modal cloud (CV inference offload)
 modal==1.4.2


### PR DESCRIPTION
## Summary

Bumps three vulnerable direct deps in both `requirements.txt` and `requirements-droplet.txt` to clear all 24 open Dependabot alerts.

| Package | Was | Now | Why |
|---|---|---|---|
| `aiohttp` | 3.13.3 | 3.13.5 | Covers the full CVE chain: trailer-header DoS, multipart bypass, duplicate Host headers, response splitting via `\r` in reason phrase, null bytes in C parser, late multipart size enforcement, unbounded DNS cache DoS, CRLF in multipart content-type, Cookie/Proxy-Auth leak on cross-origin redirect, Windows UNC SSRF in static resource handler. |
| `requests` | 2.32.4 | 2.34.2 | Insecure temp file reuse in `extract_zipped_paths`. |
| `python-dotenv` | 1.0.1 | 1.2.2 | Symlink follow in `set_key`. (Bot only calls `load_dotenv()` so not exploitable here — bumped anyway because the cost is trivial.) |

## Risk assessment

Honest triage of the 24 alerts: ~4-6 of them represent real exposure for this codebase (the aiohttp **server-side** CVEs that hit the `UserInterface/` aiohttp web server). The rest are either client-side patterns the bot doesn't trigger (no user-controlled multipart upload content-type, no cross-origin redirect chase, fixed set of outbound hosts so no DNS cache fill) or call sites the bot never uses (`requests.extract_zipped_paths`, `dotenv.set_key`). Bumping all three clears everything anyway.

## Compatibility

All three are minor/patch bumps. `aiohttp` 3.13.x line, `requests` 2.x line, `python-dotenv` 1.x line. No breaking API changes expected. Python 3.12 (per droplet) is supported by all target versions.

## Deployment

`deploy.sh` runs `pip install -r requirements-droplet.txt` only when `requirements-droplet.txt` changes (per the journal entry I saw earlier). This PR touches that file, so the 5am America/Chicago timer will pull + reinstall + restart `tomcat.service` automatically.

## Test plan

- [ ] CI (if any) passes.
- [ ] After deploy: bot comes up cleanly (`systemctl status tomcat`).
- [ ] After deploy: identify, meow, feeding sheet sync, gmail polling all still work.
- [ ] After deploy: Dependabot alerts auto-resolve (or manually dismiss the closed ones).

## Out of scope (separate work)

- CodeQL alerts (#83, #84 incomplete URL substring sanitization in `tomcat/handlers/dues.py:2518`; #85 information exposure via exception in `tomcat/handlers/labeler.py:6029`) — see follow-up.