### PR TITLE
dues: fix incomplete URL substring sanitization in email provider check (CodeQL #83 #84)

### DIFF
--- a/tomcat/handlers/dues.py
+++ b/tomcat/handlers/dues.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Optional, List, Tuple
 from ..logger import log_event, log_action
 from ..config import settings
 from ..utils.permissions import is_officer, officer_role_ids
-from ..utils.payments import detect_provider
+from ..utils.payments import detect_provider, domain_matches, extract_email_domain
 from . import finance
 
 try:
@@ -2511,16 +2511,29 @@ def _load_email_logs_between(start_dt: datetime, end_dt: datetime) -> List[dict]
 #--- Provider & payer extraction from emails ---
 
 def _provider_from_email(frm: str, subj: str, body: str) -> Optional[str]:
-    f = (frm or '').lower(); s = (subj or '').lower(); b = (body or '').lower()
-    if 'venmo.com' in f:
+    """Identify the payment provider for an INCOMING payment notification.
+
+    Narrower than utils.payments.detect_provider on purpose: dues processing
+    needs to distinguish "someone paid us" (income) from "we paid someone"
+    (refund / expense). Only incoming-direction markers are checked here.
+
+    Domain matching goes through `domain_matches` rather than substring `in`
+    so a hostile sender like `notifications@cash.app.attacker.com` cannot
+    impersonate Cash App by spoofing the From header (CodeQL alert
+    py/incomplete-url-substring-sanitization).
+    """
+    domain = extract_email_domain(frm)
+    s = (subj or '').lower()
+    b = (body or '').lower()
+    if domain_matches(domain, ("venmo.com",)):
         if ('paid you' in s) or ('sent you' in s) or ('paid you' in b):
             return 'venmo'
-    if 'cash.app' in f or 'squareup.com' in f or 'square.com' in f:
+    if domain_matches(domain, ("cash.app", "squareup.com", "square.com")):
         # Cash App notices often use "Payment received" in the subject and a
         # sender-name pattern in the body.
         if ('paid you' in s) or ('sent you' in s) or ('paid you' in b) or ('payment received' in s) or ('you were sent' in b):
             return 'cashapp'
-    if 'paypal.com' in f:
+    if domain_matches(domain, ("paypal.com",)):
         if ("you've got money" in s) or ("sent you" in s) or ('payment received' in s) or ('paid you' in b):
             return 'paypal'
     return None

--- a/tomcat/utils/payments.py
+++ b/tomcat/utils/payments.py
@@ -6,7 +6,7 @@ from email.utils import parseaddr
 from typing import Optional
 
 
-def _extract_domain(from_addr: str) -> str:
+def extract_email_domain(from_addr: str) -> str:
     """Parse From header and extract lowercase domain from the email address."""
     _, email_part = parseaddr(from_addr or "")
     email_lower = (email_part or "").strip().lower()
@@ -15,11 +15,12 @@ def _extract_domain(from_addr: str) -> str:
     return ""
 
 
-def _domain_matches(domain: str, targets: tuple[str, ...]) -> bool:
+def domain_matches(domain: str, targets: tuple[str, ...]) -> bool:
     """Check if domain equals or is a subdomain of any target.
 
     Uses equality or safe .endswith() with leading dot to prevent partial matches.
-    For example, domain "evilsquare.com" won't match target "square.com".
+    For example, domain "evilsquare.com" won't match target "square.com", and
+    "cash.app.attacker.com" won't match target "cash.app".
     """
     if not domain:
         return False
@@ -30,6 +31,11 @@ def _domain_matches(domain: str, targets: tuple[str, ...]) -> bool:
         if domain.endswith("." + target):
             return True
     return False
+
+
+# Backward-compat aliases. New callers should use the names above.
+_extract_domain = extract_email_domain
+_domain_matches = domain_matches
 
 
 def detect_provider(from_addr: str, subject: str = "", body: str = "") -> Optional[str]:


### PR DESCRIPTION
## Summary

Closes CodeQL alerts #83 and #84 (Incomplete URL substring sanitization in `tomcat/handlers/dues.py:2518`). Rewrites `_provider_from_email` to parse the email From-header domain through `email.utils.parseaddr` and check equality/subdomain via `domain_matches`, instead of `'cash.app' in from_addr`-style substring matching.

## What the vulnerability allowed

A hostile sender controlling a domain like `cash.app.attacker.com` (or `evilcash.app`, or `venmo.com.evil.com`) could spoof their From header so substring matching mis-classified their email as a real Venmo / Cash App / PayPal payment notification. Downstream code would then extract a fake amount and payer name and try to credit them in the dues sheet.

## Approach

`tomcat/utils/payments.py` already had safe `_extract_domain` + `_domain_matches` helpers (used by the broader `detect_provider`) that:
- Parse the email address out of the From header with `email.utils.parseaddr` (handles `"Cash App <noreply@cash.app>"`-style headers correctly)
- Check the parsed domain with `domain == target` OR `domain.endswith("." + target)` — never partial substring

This PR:
1. Promotes those helpers from `_extract_domain` / `_domain_matches` to public `extract_email_domain` / `domain_matches`, keeping underscore-prefixed aliases for backward compat.
2. Rewrites `_provider_from_email` in `dues.py` to use `domain_matches`.

## Behavior preservation

**Important design choice**: `_provider_from_email` is intentionally **narrower** than `detect_provider`. It only matches **incoming** payment markers (\"paid you\", \"sent you\", \"payment received\", \"you were sent\"), not outgoing markers (\"you paid\", \"you spent\", \"payment to\"). This is because the dues path needs to distinguish:

- **Income** (someone paid us their dues) → record in the dues sheet
- **Outgoing** (treasurer sent a refund or vendor payment) → NOT a dues entry

`detect_provider` lives in `utils/payments.py` and stays broader; it's used by `finance.py` where directionality doesn't matter. This split is preserved.

## Manual verification

```
--- spoofing test ---
'cash.app.attacker.com'                                      -> None
'notifications@cash.app.attacker.com'                        -> None
'Cash App <noreply@cash.app.attacker.com>'                   -> None
'Cash App <noreply@evilcash.app>'                            -> None
'Cash App <noreply@cash.app>'                                -> 'cashapp'  # legit
'Notifications <notify@subdomain.cash.app>'                  -> 'cashapp'  # legit subdomain
'Venmo <venmo@venmo.com>'                                    -> 'venmo'    # legit
'Spoof <attacker@venmo.com.evil.com>'                        -> None
--- direction filter test ---
incoming             subj='John Smith paid you \$15.00'      -> 'venmo'
outgoing-venmo       subj='You paid John Smith \$15.00'      -> None
outgoing-cashapp     subj='You spent \$15.00 to John Smith'  -> None
```

All three legitimate dues call sites (`_prep_emails_between` line 691, the verify-by-email path line 1625, and `_analyze_dues` line 2791) are unchanged structurally — they still get the same provider slug for legit incoming notifications, and still get `None` for non-dues emails.

## Test plan

- [ ] After merge + 5am deploy, the next `tomcat, dues` run should still classify income emails the same way it did before.
- [ ] CodeQL alerts #83 and #84 auto-close on the next scan.

## Not in this PR

- CodeQL alert #85 (`labeler.py:6029` Information exposure via exception). After tracing the labeler auth chain, the endpoint is gated by Discord OAuth session + live role recheck + officer/labeler role + CSRF + 127.0.0.1 bind. Recommendation: dismiss #85 as "won't fix" — see follow-up notes in the conversation.