### PR TITLE
fix: event-loop starvation freeze (bot online-but-silent) + send-health observability

### DIFF
--- a/tomcat/handlers/feeding.py
+++ b/tomcat/handlers/feeding.py
@@ -1437,7 +1437,7 @@ async def _run_8pm_check(bot: discord.Client, *, force: bool = False) -> bool:
                 )
                 return True
             except Exception as e:
-                log_action("feeding_8pm_error", f"assigned_unfed=0; total_unfed={len(unfed)}", str(e))
+                log_action("feeding_8pm_error", f"assigned_unfed=0; total_unfed={len(unfed)}", f"{type(e).__name__}: {e}")
                 return False
 
         #Build a message that pings the right people
@@ -1450,7 +1450,7 @@ async def _run_8pm_check(bot: discord.Client, *, force: bool = False) -> bool:
             log_action("feeding_8pm", f"date={today_key}; unfed={len(unfed)}", "sent")
             return True
         except Exception as e:
-            log_action("feeding_8pm_error", f"unfed={len(unfed)}", str(e))
+            log_action("feeding_8pm_error", f"unfed={len(unfed)}", f"{type(e).__name__}: {e}")
             return False
 
 def _build_request_map(subs: List[dict]) -> Dict[str, int | str]:

--- a/tomcat/handlers/gmail.py
+++ b/tomcat/handlers/gmail.py
@@ -338,10 +338,16 @@ async def start_gmail_logging_scheduler(bot) -> None:
     """Independent Gmail Poller."""
     while True:
         try:
-            #Try acquire lock; if busy (manual run), skip
-            try:
-                await asyncio.wait_for(_EMAIL_LOG_LOCK.acquire(), timeout=0.5)
-                try:
+            # Skip this cycle if a manual run holds the lock. Do NOT use
+            # `wait_for(lock.acquire(), ...)`: if the acquire completes at the
+            # same moment the timeout fires, wait_for cancels it *after* the lock
+            # was taken, the TimeoutError skips the release, and the lock leaks —
+            # permanently disabling the poller until restart. `locked()` + a plain
+            # `async with` has no such race.
+            if _EMAIL_LOG_LOCK.locked():
+                pass  #Lock busy (manual run in progress) — skip this cycle
+            else:
+                async with _EMAIL_LOG_LOCK:
                     #Check for auth config but don't crash if missing
                     if os.getenv("GMAIL_CREDENTIALS_PATH") or os.path.exists("credentials/gmail_oauth_client.json"):
                         svc = await _build_gmail_service(getattr(bot, "user", None)) #Silent auth check
@@ -353,10 +359,6 @@ async def start_gmail_logging_scheduler(bot) -> None:
                             if n > 0:
                                 log_action("gmail_poller", "new_emails", f"count={n}")
                                 await finance.process_financial_emails(bot)
-                finally:
-                    _EMAIL_LOG_LOCK.release()
-            except asyncio.TimeoutError:
-                pass #Lock busy
         except Exception as e:
             log_action("gmail_poller_error", "", str(e))
         

--- a/tomcat/main.py
+++ b/tomcat/main.py
@@ -720,6 +720,12 @@ intent_router = IntentRouter()
 SPAM_ALERTS: Dict[int, Dict[str, Any]] = {}
 _SPAM_ALERT_TTL_SEC = 86400
 
+# Emoji that trigger CV identify feedback persistence. Must stay a superset of
+# the symbols accepted by vision_feedback._canonical_feedback_symbol so the
+# emoji gate in on_raw_reaction_add never drops a real ✅/❌ vote. Gating here
+# keeps the ~90% of non-feedback reactions off the thread pool.
+_CV_FEEDBACK_EMOJIS = {"✅", "✔", "✔️", "❌", "❎", "✖", "✖️"}
+
 
 def _evict_stale_spam_alerts() -> None:
     """Remove spam alert entries that moderators never acted on within the TTL."""
@@ -1862,6 +1868,17 @@ async def on_ready():
 
     _start_background_task("cv_model_preload", lambda: _preload_cv_models())
 
+    # Start the event-loop responsiveness monitor at boot (not lazily on first
+    # labeler request, which is how it used to start — meaning it was usually
+    # NOT running). It logs `labeler_event_loop_lag` when asyncio.sleep overshoots,
+    # which is the early-warning signal for the single-core starvation that makes
+    # the bot go silent-but-online. Logs only; never user-visible.
+    try:
+        from .handlers.labeler import _ensure_loop_lag_monitor
+        _ensure_loop_lag_monitor()
+    except Exception as e:
+        log_action("loop_lag_monitor_start_error", f"type={type(e).__name__}", str(e))
+
     # Modal keep-warm runs in activity-window mode by default: the pinger is
     # spawned on-demand by handlers/vision.py after each user request and
     # exits after settings.cv_modal_activity_window_sec of idle time.
@@ -2014,7 +2031,9 @@ async def on_message(message: discord.Message):
     try:
         await _handle_misc_raw(message, now_ts=time.time(), allow_in_channels=None)
     except Exception as e:
-        log_action("handle_misc_error", f"ch={getattr(message.channel, 'id', '?')}", str(e))
+        # Include the exception TYPE: a bare TimeoutError has an empty str(), which
+        # previously made these logs read as "" and hid Discord send timeouts.
+        log_action("handle_misc_error", f"ch={getattr(message.channel, 'id', '?')}", f"{type(e).__name__}: {e}")
 
     #Build ctx once
     ctx: Dict[str, Any] = {
@@ -2041,61 +2060,71 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     """Handle reaction-based workflows (feeding + spam ban)."""
     if payload.user_id == getattr(bot.user, 'id', None):
         return
+    emoji_str = str(payload.emoji)
     # Log reactions for audit trails and moderator tooling.
+    #
+    # IMPORTANT: do NOT fetch_message here. on_raw_reaction_add fires for every
+    # reaction in the server (300+/day). A REST fetch_message per reaction was
+    # starving the single-core event loop during reaction bursts and tipping
+    # Discord sends past discord.py's 30s request timeout — the bot went silent
+    # while staying online (gateway is a separate socket). Use the in-memory
+    # message cache only (zero REST). Preview/author are best-effort: blank when
+    # the message has aged out of the cache, which is acceptable for an audit log.
     try:
         ch = bot.get_channel(int(payload.channel_id))
-        msg = None
         preview = ""
         author_name = ""
-        if ch and hasattr(ch, 'fetch_message'):
-            try:
-                msg = await ch.fetch_message(int(payload.message_id))
-                content = msg.clean_content if isinstance(getattr(msg, 'content', None), str) else ""
-                preview = content[:40] + ("..." if len(content) > 40 else "")
-                author_name = _user_label(getattr(msg, 'author', None))
-            except Exception:
-                pass
+        try:
+            cached = bot._connection._get_message(int(payload.message_id))
+        except Exception:
+            cached = None
+        if cached is not None:
+            content = cached.clean_content if isinstance(getattr(cached, 'content', None), str) else ""
+            preview = content[:40] + ("..." if len(content) > 40 else "")
+            author_name = _user_label(getattr(cached, 'author', None))
         log_event({
             "event": "reaction_add",
             "user": _user_label(getattr(payload, 'member', None)) or str(payload.user_id),
             "channel": _channel_label(ch) if ch else str(payload.channel_id),
             "message_id": int(payload.message_id),
-            "emoji": str(payload.emoji),
+            "emoji": emoji_str,
             "message_preview": preview,
             "message_author": author_name,
         })
     except Exception:
         pass
     #CV identify feedback reactions (✅/❌) are persisted for gallery retrain + manual dispute queue.
-    try:
-        from .services.vision_feedback import process_identify_reaction
-        reactor_name = _user_label(getattr(payload, "member", None)) or str(payload.user_id)
-        handled_cv_feedback = await asyncio.to_thread(
-            process_identify_reaction,
-            reply_message_id=int(payload.message_id),
-            emoji=str(payload.emoji),
-            reactor_user_id=int(payload.user_id),
-            reactor_name=reactor_name,
-        )
-        if handled_cv_feedback:
-            return
-    except Exception as e:
-        log_action("viz_feedback_reaction_error", f"msg={payload.message_id}", str(e))
+    # Gate on the emoji BEFORE spawning a thread so the ~90% of reactions that
+    # are ❤️/😭/etc. never touch the thread pool (more single-core headroom).
+    if emoji_str in _CV_FEEDBACK_EMOJIS:
+        try:
+            from .services.vision_feedback import process_identify_reaction
+            reactor_name = _user_label(getattr(payload, "member", None)) or str(payload.user_id)
+            handled_cv_feedback = await asyncio.to_thread(
+                process_identify_reaction,
+                reply_message_id=int(payload.message_id),
+                emoji=emoji_str,
+                reactor_user_id=int(payload.user_id),
+                reactor_name=reactor_name,
+            )
+            if handled_cv_feedback:
+                return
+        except Exception as e:
+            log_action("viz_feedback_reaction_error", f"msg={payload.message_id}", f"{type(e).__name__}: {e}")
     # ❓ reaction expands the embed to show top-5 candidates per detected cat.
     # Dispatched via raw_reaction_add (not client.wait_for) so message-cache
     # eviction doesn't silently drop the response.
-    if str(payload.emoji) == "❓":
+    if emoji_str == "❓":
         try:
             from .handlers.vision import handle_top5_reaction
             if await handle_top5_reaction(int(payload.message_id)):
                 return
         except Exception as e:
-            log_action("viz_top5_dispatch_error", f"msg={payload.message_id}", str(e))
+            log_action("viz_top5_dispatch_error", f"msg={payload.message_id}", f"{type(e).__name__}: {e}")
     data = SPAM_ALERTS.get(payload.message_id)
     if not data:
         return
-    emoji_str = str(payload.emoji)
-    
+
     #Handle checkmark = "not spam" - remove the hammer react so no one accidentally clicks it
     if emoji_str in {'✅', '✔', '✔️'}:
         try:

--- a/tomcat/utils/sender.py
+++ b/tomcat/utils/sender.py
@@ -1,6 +1,9 @@
 """Safe send helper that guards Discord HTTP errors and rate limits."""
 
 from __future__ import annotations
+import asyncio
+import time
+from collections import deque
 from typing import Any
 import discord
 from ..config import settings
@@ -9,6 +12,40 @@ from ..logger import log_action
 
 _DISCORD_TEXT_LIMIT = 2000
 _DISCORD_CHUNK_TARGET = 1900
+
+# ---- Send-health telemetry (logs only; never user-visible) ----
+#
+# discord.py puts a 30s timeout on every HTTP request. When the single-core
+# event loop gets starved, ch.send() raises asyncio.TimeoutError and the bot
+# goes silent while still showing online (the gateway is a separate socket).
+# That failure mode was invisible because the empty str(TimeoutError) logged as
+# "". We now record every send failure with its type and, when failures cluster
+# in a short window, emit a single loud `send_health_degraded` line so the
+# starvation is obvious in the logs the next time it happens.
+_SEND_FAIL_TIMES: deque[float] = deque(maxlen=200)
+_SEND_HEALTH_WINDOW_SEC = 60.0
+_SEND_HEALTH_BURST_THRESHOLD = 3
+_SEND_HEALTH_LOG_COOLDOWN_SEC = 60.0
+_send_health_last_logged: float = 0.0
+
+
+def _note_send_failure(ch: Any, exc: BaseException) -> None:
+    """Record a failed Discord send and log loudly if failures are clustering."""
+    global _send_health_last_logged
+    now = time.monotonic()
+    ch_id = getattr(ch, "id", None)
+    log_action("send_failure", f"ch={ch_id}", f"{type(exc).__name__}: {exc}")
+    _SEND_FAIL_TIMES.append(now)
+    recent = sum(1 for t in _SEND_FAIL_TIMES if now - t <= _SEND_HEALTH_WINDOW_SEC)
+    if recent >= _SEND_HEALTH_BURST_THRESHOLD and (now - _send_health_last_logged) >= _SEND_HEALTH_LOG_COOLDOWN_SEC:
+        _send_health_last_logged = now
+        log_action(
+            "send_health_degraded",
+            f"failures_{int(_SEND_HEALTH_WINDOW_SEC)}s={recent}",
+            "Discord sends are timing out/failing in a burst — likely event-loop "
+            "starvation (bot may appear online but silent). Check CV/identify load "
+            "and per-reaction work.",
+        )
 
 
 def _chunk_text(text: str, limit: int = _DISCORD_CHUNK_TARGET) -> list[str]:
@@ -47,9 +84,18 @@ async def safe_send(ch: Any, text: str = "", **kwargs: Any) -> None:
         log_action("send_target_invalid", f"type={type(ch).__name__}", "no_send")
         return
     payload = str(text or "")
-    if kwargs or len(payload) <= _DISCORD_TEXT_LIMIT:
-        await ch.send(payload, **kwargs)
-        return
-    chunks = _chunk_text(payload)
-    for part in chunks:
-        await ch.send(part)
+    # Record send failures for telemetry, then re-raise so callers' existing
+    # error handling is unchanged. CancelledError is intentionally NOT counted
+    # (it's normal task teardown, not a Discord failure).
+    try:
+        if kwargs or len(payload) <= _DISCORD_TEXT_LIMIT:
+            await ch.send(payload, **kwargs)
+            return
+        chunks = _chunk_text(payload)
+        for part in chunks:
+            await ch.send(part)
+    except asyncio.CancelledError:
+        raise
+    except BaseException as e:
+        _note_send_failure(ch, e)
+        raise


### PR DESCRIPTION
## The bug

Recurring freeze where the bot **stays online in Discord but stops responding** to commands (meow, identify, feeding pings) for a stretch, then recovers — sometimes on its own, sometimes only after a restart. It **predates the Modal migration**, so it's not a host/GPU issue.

## Root cause: event-loop starvation on a 1-vCPU host

Evidence from the 2026-05-28 incident (logs + journal on the droplet):

- A cluster of `TimeoutError`s hit **multiple unrelated subsystems at once** — `viz_identify_error`, `handle_misc_error` (meow), `intent_router_error`, and the `feeding_8pm` ping — while **Google Sheets writes in the same window succeeded** (`sheet_mark ok`). izzyballz even typed "no tom ping?!" — the feeding *message* never sent though the sheet update did.
- The journal showed **no discord.py "heartbeat blocked" warnings**, so the loop was **not** synchronously blocked — and the bot never dropped offline (gateway is a separate socket). It also **recovered with no restart** (`NRestarts=0`).
- discord.py 2.4.0 sets a **30s timeout on every HTTP request** (`http.py` `'timeout': 30.0`). A bare `asyncio.TimeoutError` has an **empty `str()`**, which is why these errors logged as `""` and were invisible.

So: on the **1 vCPU / 2GB** droplet, the asyncio loop shares the single core with the thread pool (GIL-serialized). During a work burst the loop can't push REST requests through within 30s → `ch.send()`/`edit()` raise `TimeoutError` → bot goes silent while staying online. This is why it predates Modal: pre-Modal, in-process CV inference pegged the core on every identify; the starvation mechanism is the same.

### Biggest contributor: a REST call per reaction
`on_raw_reaction_add` did `await ch.fetch_message()` on **every** reaction (306 on the freeze day; 27 in the freeze window) purely to log a 40-char preview. Stacked on an identify burst + the 8pm scheduler, that's ~50+ REST calls crammed into a few minutes on one core — enough to tip it over.

## Changes

### Tier 1 — remove the per-reaction REST tax
- **Drop `fetch_message`** in the reaction logger; read discord.py's in-memory message cache via `bot._connection._get_message` (zero REST). Preview/author become best-effort — blank when the message has aged out of cache, which is fine for an audit log.
- **Gate CV-feedback work on the emoji *before* spawning a thread**, so the ~90% of reactions that aren't ✅/❌ never hit the thread pool. (`_CV_FEEDBACK_EMOJIS` is a superset of what `vision_feedback._canonical_feedback_symbol` accepts, so no real vote is dropped.)

### Tier 3 — observability (logs only, never user-visible) + a latent bug
- **`safe_send` send-health telemetry:** records every send failure with its exception **type**, and emits a single loud `send_health_degraded` line when failures cluster (≥3 in 60s, with cooldown), then **re-raises** so existing caller error handling is unchanged. `CancelledError` is excluded (normal teardown).
- **Start the event-loop lag monitor at boot.** It previously only started on the first labeler request, so it was usually *not running* — which is why last night's starvation produced zero `labeler_event_loop_lag` telemetry. Now it always runs and will flag the loop overshoot early.
- **Log `type(e).__name__`** in `handle_misc_error` and `feeding_8pm_error` so bare `TimeoutError`s stop logging as `""`.
- **Fix a `wait_for(lock.acquire(), 0.5)` cancellation race** in the gmail poller that could leak `_EMAIL_LOG_LOCK` and silently disable email polling until restart. Replaced with a `locked()` check + plain `async with`.

## Test plan
- [x] AST + import check on all four modules.
- [x] Unit-tested `safe_send`: failures logged with type, burst `send_health_degraded` fires once (cooldown), `TimeoutError` re-raised to caller, `CancelledError` not counted.
- [ ] After deploy: reactions still appear in the audit log (preview present for recent messages, blank for old ones); ✅/❌ identify feedback still persists; ❓ still expands top-5.
- [ ] After deploy: during an identify burst, confirm meow/feeding still respond (or, if degraded, that `send_health_degraded` + `labeler_event_loop_lag` now show up in logs).

## Deliberately NOT in this PR
- **Tier 2 — identify burst backpressure** (cap queued identifies). Follow-up.
- **2-vCPU droplet bump** — the real ceiling. This PR hardens against the symptom, but one core remains the fundamental constraint; recommend resizing.