### PR TITLE
fix: stop synchronous sheet/file I/O from blocking the event loop (2:39pm freeze)

### DIFF
--- a/tomcat/aliases.py
+++ b/tomcat/aliases.py
@@ -6,6 +6,7 @@ import csv
 import os
 import re
 import time
+import threading
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 from .stations import station_alias_table, station_display_for
@@ -114,11 +115,58 @@ def _parse_full_name_to_display(full: str) -> Optional[str]:
         return m.group(1).strip()
     return str(full).strip()
 
+_DYN_REFRESH_LOCK = threading.Lock()
+_DYN_REFRESH_INFLIGHT = False
+
+
 def _refresh_dyn_aliases(force: bool = False) -> None:
-    global _DYN_CAT_ALIASES, _DYN_DISPLAY, _DYN_LAST_TS
+    """Refresh dynamic cat aliases without ever blocking the event loop.
+
+    The real work (_do_dyn_alias_refresh) does a synchronous gspread
+    get_all_values() over the network — on a slow / RAM-pressured host that can
+    take several seconds. This is reached from the hot message path via
+    resolve_station_or_cat(), so running it inline on the asyncio loop stalled
+    the loop long enough to miss heartbeats and drop the Discord gateway
+    (the recurring "online but silent" freeze). On TTL expiry we now kick a
+    single background thread and return immediately; callers keep serving the
+    existing in-memory cache + the local-CSV fallback in resolve_* until the
+    refresh lands. force=True (admin recache) runs inline and MUST be called
+    off-loop (see handlers/admin.py, which wraps it in asyncio.to_thread).
+    """
+    global _DYN_REFRESH_INFLIGHT, _DYN_LAST_TS
     now = time.monotonic()
     if not force and (now - _DYN_LAST_TS) < _DYN_TTL_SEC:
         return
+    if force:
+        _do_dyn_alias_refresh()
+        return
+    with _DYN_REFRESH_LOCK:
+        if _DYN_REFRESH_INFLIGHT:
+            return
+        _DYN_REFRESH_INFLIGHT = True
+        # Optimistically bump the timestamp so we don't re-kick a thread on
+        # every message while the fetch is in flight.
+        _DYN_LAST_TS = now
+
+    def _runner() -> None:
+        global _DYN_REFRESH_INFLIGHT
+        try:
+            _do_dyn_alias_refresh()
+        finally:
+            with _DYN_REFRESH_LOCK:
+                _DYN_REFRESH_INFLIGHT = False
+
+    threading.Thread(target=_runner, name="dyn-alias-refresh", daemon=True).start()
+
+
+def _do_dyn_alias_refresh() -> None:
+    """Blocking refresh of dynamic cat aliases from Sheets (CSV fallback).
+
+    MUST run off the event loop — either on the background thread started by
+    _refresh_dyn_aliases, or from a non-async caller.
+    """
+    global _DYN_CAT_ALIASES, _DYN_DISPLAY, _DYN_LAST_TS
+    now = time.monotonic()
     new_aliases: Dict[str, List[str]] = {}
     new_display: Dict[str, str] = {}
     #Try Sheets first

--- a/tomcat/handlers/admin.py
+++ b/tomcat/handlers/admin.py
@@ -206,7 +206,9 @@ async def handle_recache_catabase(args: Dict[str, Any], ctx: Dict[str, Any]) -> 
     try:
         count = await PC.refresh_async()
         try:
-            ALIAS.refresh_aliases_now()
+            # Off-loop: refresh_aliases_now() does a synchronous gspread fetch;
+            # running it inline here would block the event loop.
+            await asyncio.to_thread(ALIAS.refresh_aliases_now)
         except Exception:
             pass
         try:

--- a/tomcat/stations.py
+++ b/tomcat/stations.py
@@ -71,7 +71,26 @@ def _clean_stations(stations: List[Dict]) -> List[Dict]:
     return cleaned
 
 
+_VERSIONS_CACHE: Optional[List[Dict]] = None
+_VERSIONS_CACHE_MTIME: Optional[float] = None
+
+
 def _load_versions() -> List[Dict]:
+    # Cache parsed versions keyed on the stations file mtime. This function is
+    # reached from the hot path (_canonical_station -> station_alias_table ->
+    # _resolve_version, called per-station in loops like build_morning_message
+    # and on every message that resolves a station name). Re-reading + JSON-
+    # parsing the file on every call was hundreds of synchronous reads on the
+    # event loop — cheap normally, but seconds of stall when the host is
+    # swapping. Now we only re-parse when the file actually changes.
+    global _VERSIONS_CACHE, _VERSIONS_CACHE_MTIME
+    try:
+        _mtime = STATIONS_PATH.stat().st_mtime if STATIONS_PATH.exists() else None
+    except OSError:
+        _mtime = None
+    if _VERSIONS_CACHE is not None and _VERSIONS_CACHE_MTIME == _mtime:
+        return _VERSIONS_CACHE
+
     def _read_ndjson(path: Path) -> List[Dict]:
         out: List[Dict] = []
         if not path.exists():
@@ -122,6 +141,9 @@ def _load_versions() -> List[Dict]:
     for v in versions:
         v["effective_from"] = v.get("effective_from") or _DEFAULT_EFFECTIVE
         v["stations"] = _clean_stations(v.get("stations") or [])
+
+    _VERSIONS_CACHE = versions
+    _VERSIONS_CACHE_MTIME = _mtime
     return versions
 
 


### PR DESCRIPTION
## What this fixes

The 2026-05-30 ~2:39pm CDT freeze. The boot-time loop watchdog from #74 captured the main-thread stack at the stall, which pinpointed the cause: **synchronous I/O running directly on the asyncio event loop.**

Two stall stacks:
1. `requests → urllib3 → socket.recv` — a blocking gspread `get_all_values()` on the loop.
2. `build_morning_message → _canonical_station → … → _read_ndjson → os.stat` — the stations file re-read (uncached) hundreds of times per build.

On the droplet (actively swapping, ~98% CPU) every blocking syscall stalls for *seconds* instead of microseconds, so these froze the loop long enough to miss heartbeats, drop the Discord gateway, and fail to reconnect for ~3 minutes (19:51–19:54 UTC) → "online but silent."

**This is a different root cause than #74** (which fixed the per-reaction REST storm). #74 wasn't the wrong fix — and critically, its telemetry is the only reason this one was diagnosable instead of guesswork.

## Changes

- **`aliases.py`** — `_refresh_dyn_aliases` no longer does the gspread fetch inline. It's reached from the hot message path (`resolve_station_or_cat`, every message that resolves a cat/station name) on a 2-hour TTL, so every ~2h the first such message blocked the loop on a ~991-row sheet fetch. Now on TTL expiry it kicks a **single background daemon thread** and returns immediately; resolution keeps serving the in-memory cache + local-CSV fallback until the refresh lands. `force=True` (admin recache) still runs inline.
- **`handlers/admin.py`** — the manual "recache" command wraps `refresh_aliases_now()` in `asyncio.to_thread` so it can't block the loop either.
- **`stations.py`** — `_load_versions` now caches parsed versions keyed on the file's mtime, eliminating the per-call `read_text` + JSON parse on the hot path (re-parses only when the stations file changes).

## Verification

```
stations cache same object: True
non-force refresh returned in 1ms (expect <50ms, NOT ~2000ms)
single-flight: _do called once during inflight window: True
force=True ran inline in 2000ms (expect ~2000ms): True
```

Plus AST + import checks on all three files.

## Follow-up (not in this PR)

`dues.py`/`finance.py` also call `get_all_values()` on the loop via `_load_membership_rows` on cache miss. Lower frequency (300s TTL, infrequent scheduler) so it wasn't today's trigger, but it should move off-loop too. Flagging rather than half-refactoring the dues subsystem here.

## Still the underlying ceiling

The droplet is RAM-exhausted (swapping). These fixes make the bot degrade gracefully instead of freezing when I/O is slow, but the host is undersized — hence the separate hosting-options discussion.