### PR TITLE
spam: detect "moving abroad, free furniture, DM me" giveaway scam

### DIFF
--- a/tomcat/spam.py
+++ b/tomcat/spam.py
@@ -24,7 +24,24 @@ SUSPICIOUS_TERMS = [
     ("season_tickets", 1, re.compile(r"\bseason\s+tickets?\b", re.I)),
     ("selling_tickets", 1, re.compile(r"\bsell(?:ing)?\s+(?:my\s+)?tickets?\b", re.I)),
     ("whatsapp", 1, re.compile(r"\bwhats?app\b", re.I)),
+    #"Moving abroad, giving away my furniture for free, DM me" giveaway scam.
+    ("relocating_pretext", 2, re.compile(r"\b(?:relocat\w*|moving|leaving)\b.{0,40}\b(?:new\s+(?:country|state|city|place)|abroad|overseas|out\s+of\s+(?:the\s+)?(?:country|state|town)|to\s+a\s+new)\b", re.I)),
+    ("giving_away_items", 2, re.compile(r"\b(?:give\s+(?:out|away)|giving\s+(?:out|away|them\s+out)|giv(?:e|ing)\s+them\s+(?:out|away))\b.{0,40}\b(?:item|items|belongings|stuff|everything|furniture|free)\b", re.I)),
+    ("free_of_charge", 1, re.compile(r"\bfree\s+of\s+charge\b|\bcompletely\s+free\b|\bfor\s+free\b", re.I)),
+    ("dm_me_for_details", 1, re.compile(r"\b(?:dm|pm|message|text|inbox)\s+me\s+for\s+(?:more\s+)?(?:detail|details|info|information|pic|pics|picture|pictures)\b", re.I)),
+    ("send_me_a_message", 1, re.compile(r"\bsend\s+me\s+a\s+(?:message|dm|text|note)\b", re.I)),
 ]
+
+#Household goods / appliances frequently dumped in the giveaway-scam item list.
+HOUSEHOLD_ITEM_RE = re.compile(
+    r"\b(?:trampoline|treadmill|freezer|fridge|refrigerator|washer|dryer|dishwasher|"
+    r"microwave|mattress|dresser|couch|sofa|sectional|bunk\s*bed|kennel|"
+    r"water\s+dispenser|kitchen\s*aid|stand\s*mixer|smart\s*tv|x\s*box|xbox|"
+    r"ps\s*[45]|playstation|wardrobe|recliner|loveseat|ottoman|bookshelf|nightstand)\b",
+    re.I,
+)
+#Distinct household items needed before the long-list density signal fires.
+HOUSEHOLD_ITEM_THRESHOLD = 5
 
 MIN_SPAM_SCORE = 3
 
@@ -150,11 +167,18 @@ def check_spam(message, settings) -> tuple[bool, str]:
         if rx.search(text):
             score += 2
             matched_rules.append(rx.pattern)
+    #Long list of household goods is the tell for the "moving abroad" giveaway scam.
+    item_hits = {m.group(0).lower() for m in HOUSEHOLD_ITEM_RE.finditer(text)}
+    item_count = len(item_hits)
+    if item_count >= HOUSEHOLD_ITEM_THRESHOLD:
+        score += 2
     #fuzzy phrases
     fuzzy_phrases = [
         "tickets available", "4 tickets", "american airlines center",
         "dm me if interested", "message me if interested", "first come first serve",
         "free macbook", "giving out my macbook", "free iphone","at&t stadium", "ps5 charger",
+        "relocating to a new country", "give out my items", "free of charge",
+        "moving abroad", "everything must go", "excellent condition",
     ]
     fuzzy_hits = []
     for ph in fuzzy_phrases:
@@ -172,6 +196,8 @@ def check_spam(message, settings) -> tuple[bool, str]:
             details_parts.append(f"phrases={','.join(suspicion_hits)}")
         if matched_rules:
             details_parts.append(f"regex={'|'.join(matched_rules)}")
+        if item_count >= HOUSEHOLD_ITEM_THRESHOLD:
+            details_parts.append(f"items={item_count}")
         if fuzzy_hits:
             details_parts.append(f"fuzzy={len(fuzzy_hits)}")
         if details_parts:


### PR DESCRIPTION
## What

Adds spam detection for the **"I'm relocating to a new country, giving away my furniture for free, DM me"** giveaway scam. The detector previously scored a real instance of this message **0/3** — existing rules only cover ticket resale and free-electronics scams, so this family passed straight through.

## How

Uses the existing weighted-scoring approach in `tomcat/spam.py`, so it composes with the trust-gate exemptions (officers, trusted roles, and 50+ message members stay exempt — and these scams come from brand-new accounts anyway).

- **New `SUSPICIOUS_TERMS`:** `relocating_pretext`, `giving_away_items`, `free_of_charge`, `dm_me_for_details`, `send_me_a_message`.
- **New household-item density signal** (`HOUSEHOLD_ITEM_RE`): 5+ distinct appliances/furniture in one message adds +2 — the structural tell of the scam's long item dump. Count is logged (`items=N`) so moderators can see why it fired.
- **New fuzzy phrases** for the recurring boilerplate ("relocating to a new country", "excellent condition", etc.).

## Verification

No spam tests exist in the repo, so verified against an isolated harness:

| Message | Score | Flagged |
|---|---|---|
| The giveaway scam | 13 | ✅ yes |
| "Moving to a new apartment, anyone help carry a couch?" | 2 | no |
| Club meeting reminder / study group / free pizza | 0 | no |

Benign "moving" chatter only trips one signal (under the threshold of 3), and the density signal's 5-item floor keeps normal conversation from tripping it.