### PR TITLE
Handle cat profile image upload failures gracefully

### DIFF
--- a/tomcat/handlers/cats.py
+++ b/tomcat/handlers/cats.py
@@ -500,8 +500,16 @@ async def handle_cat_profile(intent: 'Intent', ctx: dict) -> None:
     e.description = "\n".join(lines)
     img_bytes, filename = await _build_latest_profile_image_payload(str(actual))
     if img_bytes and filename:
-        file = discord.File(io.BytesIO(img_bytes), filename=filename)
-        e.set_image(url=f"attachment://{filename}")
-        await ch.send(embed=e, file=file)
-        return
+        try:
+            file = discord.File(io.BytesIO(img_bytes), filename=filename)
+            e.set_image(url=f"attachment://{filename}")
+            await ch.send(embed=e, file=file)
+            return
+        except Exception as exc:
+            #A photo that can't be uploaded (too large, unsupported, network error)
+            #must not swallow the whole profile response. Fall back to text-only so
+            #"who is <cat>" always replies. This notably affects heavily photographed
+            #cats like Microwave, whose latest image can exceed Discord's upload limit.
+            log_action("cat_profile_image_send_failed", str(actual), f"{type(exc).__name__}: {exc}")
+            e.set_image(url=None)
     await ch.send(embed=e)


### PR DESCRIPTION
## Summary
Added error handling for cat profile image uploads to prevent failures from blocking the entire profile response. If an image cannot be uploaded (due to size limits, unsupported formats, or network errors), the profile will now fall back to text-only display instead of failing completely.

## Changes
- Wrapped the image file creation and upload logic in a try-except block
- On image upload failure, logs the error and clears the image from the embed
- Falls back to sending the profile embed without an image attachment
- Ensures the "who is <cat>" command always returns a response, even when image uploads fail

## Implementation Details
- The error handler catches all exceptions during the `discord.File` creation and `ch.send()` call
- Logs the failure with the exception type and message for debugging
- Particularly addresses cases where heavily photographed cats have images exceeding Discord's upload size limit (e.g., Microwave)
- The text-only fallback ensures users still get the cat profile information even when images cannot be attached

https://claude.ai/code/session_015h2o6HSEsP3ET7MamLXKaG